### PR TITLE
Fix multi-agent slide generation errors and timeout issues

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
     port: 3000,
     reuseExistingServer: !process.env.CI,
     timeout: 60 * 1000,
-    env: {
-      ...process.env,
-    },
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([_, value]) => value !== undefined)
+    ) as { [key: string]: string },
   },
 });

--- a/frontend/src/app/api/v1/slides/route.ts
+++ b/frontend/src/app/api/v1/slides/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
     const taskId = uuidv4();
     
     // タスクを作成
-    const task = taskStorage.createTask(taskId, prompt, file ? [file.name] : undefined);
+    taskStorage.createTask(taskId, prompt, file ? [file.name] : undefined);
     console.log(`[API] Created task: ${taskId}`);
     console.log(`[API] Task storage now has ${taskStorage.getAllTasks().length} tasks`);
 

--- a/frontend/src/app/slides/[taskId]/page.tsx
+++ b/frontend/src/app/slides/[taskId]/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
-import { SlideDocument, SlideData } from '@/types/api';
+import Link from 'next/link';
+import { SlideData } from '@/types/api';
 
 export default function SlideView() {
   const params = useParams();
@@ -12,27 +13,7 @@ export default function SlideView() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchSlides();
-  }, [taskId]);
-
-  // キーボードナビゲーション
-  useEffect(() => {
-    const handleKeyPress = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') {
-        prevSlide();
-      } else if (e.key === 'ArrowRight') {
-        nextSlide();
-      } else if (e.key === 'Escape') {
-        window.location.href = '/';
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyPress);
-    return () => window.removeEventListener('keydown', handleKeyPress);
-  }, [currentSlide, slides.length]);
-
-  const fetchSlides = async () => {
+  const fetchSlides = useCallback(async () => {
     try {
       const response = await fetch(`/api/v1/tasks/${taskId}`);
       if (!response.ok) {
@@ -52,19 +33,39 @@ export default function SlideView() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [taskId]);
 
-  const nextSlide = () => {
+  const nextSlide = useCallback(() => {
     if (currentSlide < slides.length - 1) {
       setCurrentSlide(currentSlide + 1);
     }
-  };
+  }, [currentSlide, slides.length]);
 
-  const prevSlide = () => {
+  const prevSlide = useCallback(() => {
     if (currentSlide > 0) {
       setCurrentSlide(currentSlide - 1);
     }
-  };
+  }, [currentSlide]);
+
+  useEffect(() => {
+    fetchSlides();
+  }, [fetchSlides]);
+
+  // キーボードナビゲーション
+  useEffect(() => {
+    const handleKeyPress = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        prevSlide();
+      } else if (e.key === 'ArrowRight') {
+        nextSlide();
+      } else if (e.key === 'Escape') {
+        window.location.href = '/';
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyPress);
+    return () => window.removeEventListener('keydown', handleKeyPress);
+  }, [nextSlide, prevSlide]);
 
   const goToSlide = (index: number) => {
     setCurrentSlide(index);
@@ -86,9 +87,9 @@ export default function SlideView() {
       <div className="min-h-screen flex items-center justify-center bg-gray-100">
         <div className="text-center">
           <p className="text-red-600">{error}</p>
-          <a href="/" className="mt-4 inline-block text-blue-600 hover:underline">
+          <Link href="/" className="mt-4 inline-block text-blue-600 hover:underline">
             ホームに戻る
-          </a>
+          </Link>
         </div>
       </div>
     );
@@ -206,7 +207,7 @@ export default function SlideView() {
         </div>
 
         {/* 戻るボタン */}
-        <a
+        <Link
           href="/"
           className="absolute top-8 left-8 text-gray-400 hover:text-white flex items-center space-x-2"
         >
@@ -214,7 +215,7 @@ export default function SlideView() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
           </svg>
           <span>ホームに戻る</span>
-        </a>
+        </Link>
       </div>
 
       {/* キーボードショートカット情報 */}

--- a/frontend/src/app/tasks/[taskId]/page.tsx
+++ b/frontend/src/app/tasks/[taskId]/page.tsx
@@ -18,7 +18,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ taskId: s
     if (!taskId) return;
 
     const pollTaskStatus = async () => {
-      const maxAttempts = 60;
+      const maxAttempts = 300; // 5分間に延長
       let attempts = 0;
 
       // 初回ポーリング前に少し待機（タスク作成を確実にするため）

--- a/frontend/src/components/AgentProgress.tsx
+++ b/frontend/src/components/AgentProgress.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { AgentProgress } from '@/lib/agents/progressTracker';
 
 interface AgentProgressProps {

--- a/frontend/src/lib/agents/researchAgent.ts
+++ b/frontend/src/lib/agents/researchAgent.ts
@@ -27,7 +27,18 @@ export class ResearchAgent {
   ): Promise<ResearchResult[]> {
     const results: ResearchResult[] = [];
 
-    for (const query of section.researchQueries) {
+    // researchQueriesが配列でない場合のフォールバック
+    const queries = Array.isArray(section.researchQueries) 
+      ? section.researchQueries 
+      : [];
+
+    if (queries.length === 0) {
+      console.warn(`[ResearchAgent] No research queries for section: ${section.title}`);
+      // デフォルトクエリを使用
+      queries.push(section.title);
+    }
+
+    for (const query of queries) {
       try {
         // Web検索をシミュレート（実際の実装では外部APIを使用）
         const searchResults = await this.simulateWebSearch(query);

--- a/frontend/src/lib/agents/types.ts
+++ b/frontend/src/lib/agents/types.ts
@@ -26,7 +26,7 @@ export interface Message {
   to: AgentType;
   content: string;
   timestamp: Date;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export type AgentType = 'planner' | 'researcher' | 'writer' | 'reviewer' | 'coordinator';
@@ -46,6 +46,8 @@ export interface PlanSection {
   researchQueries: string[];
   expectedContent: string[];
   priority: 'high' | 'medium' | 'low';
+  estimatedSlides?: number;
+  splitStrategy?: string;
 }
 
 export interface ResearchResult {
@@ -106,14 +108,14 @@ export interface SlideData {
 
 export interface VisualElement {
   type: 'image' | 'chart' | 'diagram';
-  data: any;
+  data: unknown;
   caption?: string;
 }
 
 // エージェントのアクション定義
 export interface AgentAction {
   type: string;
-  payload: any;
+  payload: unknown;
 }
 
 export interface PlannerActions {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -22,7 +22,7 @@ export interface SlideData {
   id?: string;
   title: string;
   content?: string;
-  type: 'title' | 'content' | 'image' | 'chart';
+  type: 'title' | 'content' | 'image' | 'chart' | 'conclusion';
   image_url?: string;
   chart_data?: unknown;
   speakerNotes?: string;
@@ -69,6 +69,15 @@ export interface AgentProgress {
     content: string;
     timestamp: Date;
   }>;
+  detailedStats?: {
+    totalSections: number;
+    estimatedTotalSlides: number;
+    actualSlides: number;
+    researchQueries: number;
+    researchResults: number;
+    initialResearchCount: number;
+    allocatedContentPoints: number;
+  };
 }
 
 export interface Task {


### PR DESCRIPTION
## Summary
- Fix critical errors in multi-agent slide generation workflow
- Extend timeout to handle longer processing times
- Optimize performance with batch processing

## Changes Made
1. **Error Fixes**
   - Fix "researchQueries is not iterable" error by adding array checks and fallbacks
   - Fix "this.shouldSplitIntoMultipleSlides is not a function" error 
   - Fix TypeScript build errors across multiple files

2. **Performance Improvements**
   - Extend task polling timeout from 60s to 300s (5 minutes)
   - Implement batch processing for research phase (3 sections at a time)
   - Implement batch processing for writing phase (2 sections at a time)

3. **Type Safety**
   - Add proper type definitions for all agent methods
   - Fix ESLint errors and remove unused imports
   - Add 'conclusion' slide type to API types

4. **Error Handling**
   - Add defensive checks for undefined/non-array values
   - Implement fallback behaviors when data is missing
   - Improve error messages and logging

## Test Plan
- [x] Build passes without errors
- [ ] Multi-agent workflow completes successfully
- [ ] Slide generation handles complex prompts
- [ ] UI displays agent progress correctly

🤖 Generated with [Claude Code](https://claude.ai/code)